### PR TITLE
ensure quarkus cli runs with java 17 minimum by default

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -14,13 +14,16 @@
       "description": "Script that publishes an extension catalog to a registry"
     },
     "cli": {
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar"
+      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar",
+      "java-version": "17+"
     },
     "qs": {
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar"
+      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar",
+      "java-version": "17+"
     },
     "quarkus": {
-      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar"
+      "script-ref": "https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/3.21.2/quarkus-cli-3.21.2-runner.jar",
+      "java-version": "17+"
     },
     "quarkus-kill": {
       "script-ref": "kill.java"


### PR DESCRIPTION
some pinged me saying they get verification error running the cli and turned out that their default jdk was java 8 so it failed.

this makes jbang will use 17+ when available or fetch java 17 if need be.