### PR TITLE
feat: add quarkus-agent-mcp alias

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -31,6 +31,11 @@
     "kill": {
       "script-ref": "kill.java"
     },
+    "quarkus-agent-mcp": {
+      "script-ref": "io.quarkus:quarkus-agent-mcp:RELEASE:runner",
+      "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications",
+      "java-version": "21+"
+    },
     "quarkus-fmt": {
       "script-ref": "fmt.java"
     },


### PR DESCRIPTION
Add a JBang alias for the [Quarkus Agent MCP](https://github.com/quarkusio/quarkus-agent-mcp) server, so users can install it via:

```bash
jbang quarkus-agent-mcp@quarkusio
```

The alias resolves the uber-jar from Maven Central using `RELEASE`, so it always picks up the latest version. Requires Java 21+.